### PR TITLE
Revert "[action] [PR:1508] [hash] update ECMP/LAG hash VS lib with SAI_NATIVE_HASH_FIELD_IPV6_FLOW_LABEL"

### DIFF
--- a/syncd/tests/TestSyncdMlnx.cpp
+++ b/syncd/tests/TestSyncdMlnx.cpp
@@ -208,8 +208,7 @@ TEST_F(SyncdMlnxTest, queryAttrEnumValuesCapability)
         SAI_NATIVE_HASH_FIELD_INNER_DST_IP,
         SAI_NATIVE_HASH_FIELD_INNER_SRC_IP,
         SAI_NATIVE_HASH_FIELD_INNER_L4_DST_PORT,
-        SAI_NATIVE_HASH_FIELD_INNER_L4_SRC_PORT,
-        SAI_NATIVE_HASH_FIELD_IPV6_FLOW_LABEL
+        SAI_NATIVE_HASH_FIELD_INNER_L4_SRC_PORT
     };
 
     std::set<sai_native_hash_field_t> hfSet2;

--- a/unittest/vslib/TestSwitchStateBase.cpp
+++ b/unittest/vslib/TestSwitchStateBase.cpp
@@ -126,8 +126,7 @@ TEST_F(SwitchStateBaseTest, switchHashCapabilitiesGet)
         SAI_NATIVE_HASH_FIELD_INNER_DST_IP,
         SAI_NATIVE_HASH_FIELD_INNER_SRC_IP,
         SAI_NATIVE_HASH_FIELD_INNER_L4_DST_PORT,
-        SAI_NATIVE_HASH_FIELD_INNER_L4_SRC_PORT,
-        SAI_NATIVE_HASH_FIELD_IPV6_FLOW_LABEL
+        SAI_NATIVE_HASH_FIELD_INNER_L4_SRC_PORT
     };
 
     std::set<sai_native_hash_field_t> hfSet2;

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -3758,13 +3758,13 @@ sai_status_t SwitchStateBase::queryHashNativeHashFieldListCapability(
 {
     SWSS_LOG_ENTER();
 
-    if (enum_values_capability->count < 19)
+    if (enum_values_capability->count < 18)
     {
-        enum_values_capability->count = 19;
+        enum_values_capability->count = 18;
         return SAI_STATUS_BUFFER_OVERFLOW;
     }
 
-    enum_values_capability->count = 19;
+    enum_values_capability->count = 18;
     enum_values_capability->list[0] = SAI_NATIVE_HASH_FIELD_IN_PORT;
     enum_values_capability->list[1] = SAI_NATIVE_HASH_FIELD_DST_MAC;
     enum_values_capability->list[2] = SAI_NATIVE_HASH_FIELD_SRC_MAC;
@@ -3783,7 +3783,6 @@ sai_status_t SwitchStateBase::queryHashNativeHashFieldListCapability(
     enum_values_capability->list[15] = SAI_NATIVE_HASH_FIELD_INNER_SRC_IP;
     enum_values_capability->list[16] = SAI_NATIVE_HASH_FIELD_INNER_L4_DST_PORT;
     enum_values_capability->list[17] = SAI_NATIVE_HASH_FIELD_INNER_L4_SRC_PORT;
-    enum_values_capability->list[18] = SAI_NATIVE_HASH_FIELD_IPV6_FLOW_LABEL;
 
     return SAI_STATUS_SUCCESS;
 }


### PR DESCRIPTION
Reverts Azure/sonic-sairedis.msft#17

Confirmed that feature is not required. Will be safe to remove the SAI switch capability support, in case anything will be broken.