### PR TITLE
[TAM]: Fix TAM notification and vslib implementation (#1606)

### DIFF
--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -14,7 +14,7 @@
 
 // TODO add validation for all oids belong to the same switch
 
-#define MAX_LIST_COUNT 0x1000
+#define MAX_LIST_COUNT (0x1<<24) // 16M
 
 #define CHECK_STATUS_SUCCESS(s) { if ((s) != SAI_STATUS_SUCCESS) return (s); }
 

--- a/meta/NotificationTamTelTypeConfigChange.cpp
+++ b/meta/NotificationTamTelTypeConfigChange.cpp
@@ -26,7 +26,7 @@ sai_object_id_t NotificationTamTelTypeConfigChange::getAnyObjectId() const
 {
     SWSS_LOG_ENTER();
 
-    return SAI_NULL_OBJECT_ID;
+    return m_tam_id;
 }
 
 void NotificationTamTelTypeConfigChange::processMetadata(

--- a/syncd/NotificationProcessor.cpp
+++ b/syncd/NotificationProcessor.cpp
@@ -788,7 +788,19 @@ void NotificationProcessor::handle_tam_tel_type_config_change(
 
     SWSS_LOG_DEBUG("TAM telemesai_serialize_object_id(tam_type_id)try type config change on TAM id %s", data.c_str());
 
-    sendNotification(SAI_SWITCH_NOTIFICATION_NAME_TAM_TEL_TYPE_CONFIG_CHANGE, data);
+    sai_object_id_t rid;
+    sai_object_id_t vid;
+    sai_deserialize_object_id(data, rid);
+
+    if (!m_translator->tryTranslateRidToVid(rid, vid))
+    {
+        SWSS_LOG_ERROR("TAM_TEL_TYPE RID %s transalted to null VID!!!", sai_serialize_object_id(rid).c_str());
+        return;
+    }
+
+    std::string vid_data = sai_serialize_object_id(vid);
+
+    sendNotification(SAI_SWITCH_NOTIFICATION_NAME_TAM_TEL_TYPE_CONFIG_CHANGE, vid_data);
 }
 
 void NotificationProcessor::processNotification(

--- a/tests/aspell.en.pws
+++ b/tests/aspell.en.pws
@@ -481,3 +481,7 @@ Enqueue
 deque
 apiversion
 vso
+VxLAN
+IPFIX
+IPFix
+ipfix

--- a/unittest/meta/TestNotificationTam.cpp
+++ b/unittest/meta/TestNotificationTam.cpp
@@ -29,5 +29,6 @@ TEST(NotificationTamTelTypeConfigChange, processMetadata)
     ss << "oid:0x" << std::hex << tam_id;
 
     NotificationTamTelTypeConfigChange n(ss.str());
+    ASSERT_EQ(tam_id, n.getAnyObjectId());
     n.processMetadata(meta);
 }

--- a/unittest/vslib/TestTAM.cpp
+++ b/unittest/vslib/TestTAM.cpp
@@ -37,6 +37,9 @@ TEST(TAM, TAMTelTypeConfigNotification)
     sai_object_id_t tam_tel_type_id = 0x4b000000000001;
     string tam_tel_type_id_str = sai_serialize_object_id(tam_tel_type_id);
 
+    sai_object_id_t tam_tel_id = 0x4b000000000002;
+    string tam_tel_id_str = sai_serialize_object_id(tam_tel_id);
+
     attrs.clear();
     attr.id = SAI_SWITCH_ATTR_TAM_TEL_TYPE_CONFIG_CHANGE_NOTIFY;
     attr.value.ptr = reinterpret_cast<void *>(notify_tam_tel_type_config_change);
@@ -48,6 +51,10 @@ TEST(TAM, TAMTelTypeConfigNotification)
 
     EXPECT_EQ(
         SAI_STATUS_SUCCESS,
+        ss.create(SAI_OBJECT_TYPE_TAM_TELEMETRY, tam_tel_id_str, switch_id, 0, nullptr));
+
+    EXPECT_EQ(
+        SAI_STATUS_SUCCESS,
         ss.create(SAI_OBJECT_TYPE_TAM_TEL_TYPE, tam_tel_type_id_str, switch_id, 0, nullptr));
 
     attr.id = SAI_TAM_TEL_TYPE_ATTR_STATE;
@@ -56,6 +63,15 @@ TEST(TAM, TAMTelTypeConfigNotification)
     EXPECT_EQ(
         SAI_STATUS_SUCCESS,
         ss.set(SAI_OBJECT_TYPE_TAM_TEL_TYPE, tam_tel_type_id_str, &attr));
+
+
+    std::vector<uint8_t> buffer(1024*1024*1024);
+    attr.id = SAI_TAM_TEL_TYPE_ATTR_IPFIX_TEMPLATES;
+    attr.value.u8list.count = static_cast<uint32_t>(buffer.size());
+    attr.value.u8list.list = buffer.data();
+    EXPECT_EQ(
+        SAI_STATUS_SUCCESS,
+        ss.get(SAI_OBJECT_TYPE_TAM_TEL_TYPE, tam_tel_type_id_str, 1, &attr));
 
     auto event = eventQueue->dequeue();
     EXPECT_EQ(event->getType(), EventType::EVENT_TYPE_NOTIFICATION);

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -9,6 +9,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <random>
 
 #define SAI_VS_MAX_PORTS 1024
 
@@ -185,6 +186,13 @@ sai_status_t SwitchStateBase::create(
     {
         // Neighbor entry programming for VOQ systems
         return createVoqSystemNeighborEntry(serializedObjectId, switch_id, attr_count, attr_list);
+    }
+
+    if (object_type == SAI_OBJECT_TYPE_TAM_TELEMETRY)
+    {
+        sai_object_id_t object_id;
+        sai_deserialize_object_id(serializedObjectId, object_id);
+        return createTamTelemetry(object_id, switch_id, attr_count, attr_list);
     }
 
     return create_internal(object_type, serializedObjectId, switch_id, attr_count, attr_list);
@@ -1138,6 +1146,18 @@ sai_status_t SwitchStateBase::set_static_crm_values()
     return set_static_acl_resource_list(SAI_SWITCH_ATTR_AVAILABLE_ACL_TABLE_GROUP, m_maxAclTableGroups);
 }
 
+sai_status_t SwitchStateBase::set_initial_tam_objects()
+{
+    SWSS_LOG_ENTER();
+
+    sai_attribute_t attr;
+    attr.id = SAI_SWITCH_ATTR_TAM_OBJECT_ID;
+    attr.value.objlist.count = 0;
+    attr.value.objlist.list = nullptr;
+
+    return set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr);
+}
+
 sai_status_t SwitchStateBase::set_static_acl_resource_list(
         _In_ sai_switch_attr_t acl_resource,
         _In_ int max_count)
@@ -1764,6 +1784,7 @@ sai_status_t SwitchStateBase::initialize_default_objects(
     CHECK_STATUS(set_switch_default_attributes());
     CHECK_STATUS(create_scheduler_groups());
     CHECK_STATUS(set_static_crm_values());
+    CHECK_STATUS(set_initial_tam_objects());
 
     // Initialize switch for VOQ attributes
 
@@ -2074,6 +2095,12 @@ sai_status_t SwitchStateBase::warm_update_switch()
     if (get(SAI_OBJECT_TYPE_SWITCH, m_switch_id, 1, &attr) != SAI_STATUS_SUCCESS)
     {
         CHECK_STATUS(set_acl_capabilities());
+    }
+
+    attr.id = SAI_SWITCH_ATTR_TAM_OBJECT_ID;
+    if (get(SAI_OBJECT_TYPE_SWITCH, m_switch_id, 1, &attr) != SAI_STATUS_SUCCESS)
+    {
+        CHECK_STATUS(set_initial_tam_objects());
     }
 
     // check for default supported object types
@@ -2608,6 +2635,11 @@ sai_status_t SwitchStateBase::refresh_read_only(
     if (meta->objecttype == SAI_OBJECT_TYPE_ACL_TABLE && meta->attrid == SAI_ACL_TABLE_ATTR_AVAILABLE_ACL_COUNTER)
     {
         return refresh_acl_table_counters(object_id);
+    }
+
+    if (meta->objecttype == SAI_OBJECT_TYPE_TAM_TEL_TYPE && meta->attrid == SAI_TAM_TEL_TYPE_ATTR_IPFIX_TEMPLATES)
+    {
+        return refresh_tam_tel_ipfix_templates(object_id);
     }
 
     auto mmeta = m_meta.lock();
@@ -4268,4 +4300,64 @@ void SwitchStateBase::send_tam_tel_type_config_change(
     auto payload = std::make_shared<EventPayloadNotification>(ntf, sn);
 
     m_switchConfig->m_eventQueue->enqueue(std::make_shared<Event>(EVENT_TYPE_NOTIFICATION, payload));
+}
+
+sai_status_t SwitchStateBase::refresh_tam_tel_ipfix_templates(sai_object_id_t tam_tel_type_id)
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<uint8_t> ipfix_templates;
+
+    // TODO: This is a placeholder for the actual logic to generate IPFIX templates.
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<uint16_t> dist(0, 255);
+    ipfix_templates.resize(64 * 1024);
+
+    for (size_t i = 0; i < ipfix_templates.size(); ++i)
+    {
+        ipfix_templates[i] = static_cast<uint8_t>(dist(gen));
+    }
+
+
+    sai_attribute_t attr;
+    attr.id = SAI_TAM_TEL_TYPE_ATTR_IPFIX_TEMPLATES;
+    attr.value.u8list.count = static_cast<uint32_t>(ipfix_templates.size());
+    attr.value.u8list.list = ipfix_templates.data();
+    sai_status_t status = set(SAI_OBJECT_TYPE_TAM_TEL_TYPE, tam_tel_type_id, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to set IPFIX templates for TAM Tel Type %s, status: %s",
+                       sai_serialize_object_id(tam_tel_type_id).c_str(),
+                       sai_serialize_status(status).c_str());
+    }
+    else
+    {
+        SWSS_LOG_INFO("Successfully set IPFIX templates for TAM Tel Type %s",
+                      sai_serialize_object_id(tam_tel_type_id).c_str());
+    }
+
+    return status;
+}
+
+sai_status_t SwitchStateBase::createTamTelemetry(
+    sai_object_id_t tam_telemetry_id,
+    sai_object_id_t switch_id,
+    uint32_t attr_count,
+    const sai_attribute_t *attr_list)
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<sai_attribute_t> attrs(attr_list, attr_list + attr_count);
+    sai_attribute_t attr;
+    attr.id = SAI_TAM_TELEMETRY_ATTR_TAM_TYPE_LIST;
+    attr.value.objlist.count = 0;
+    attr.value.objlist.list = nullptr;
+    attrs.push_back(attr);
+
+    return create_internal(SAI_OBJECT_TYPE_TAM_TELEMETRY,
+        sai_serialize_object_id(tam_telemetry_id),
+        switch_id,
+        static_cast<uint32_t>(attrs.size()),
+        attrs.data());
 }

--- a/vslib/SwitchStateBase.h
+++ b/vslib/SwitchStateBase.h
@@ -98,6 +98,8 @@ namespace saivs
 
             virtual sai_status_t set_static_crm_values();
 
+            virtual sai_status_t set_initial_tam_objects();
+
             virtual sai_status_t set_static_acl_resource_list(
                     _In_ sai_switch_attr_t acl_resource,
                     _In_ int max_count);
@@ -543,9 +545,12 @@ namespace saivs
             void send_fdb_event_notification(
                     _In_ const sai_fdb_event_notification_data_t& data);
 
-        public: // Telemetry and Monitor
+        protected: // Telemetry and Monitor
 
             void send_tam_tel_type_config_change(
+                _In_ sai_object_id_t tam_tel_type_id);
+
+            sai_status_t refresh_tam_tel_ipfix_templates(
                 _In_ sai_object_id_t tam_tel_type_id);
 
         protected:
@@ -591,6 +596,12 @@ namespace saivs
 
             sai_status_t createMACsecSC(
                     _In_ sai_object_id_t macsec_sa_id,
+                    _In_ sai_object_id_t switch_id,
+                    _In_ uint32_t attr_count,
+                    _In_ const sai_attribute_t *attr_list);
+
+            sai_status_t createTamTelemetry(
+                    _In_ sai_object_id_t tam_telemetry_id,
                     _In_ sai_object_id_t switch_id,
                     _In_ uint32_t attr_count,
                     _In_ const sai_attribute_t *attr_list);


### PR DESCRIPTION
Fix TAM notification issue that uses the wrong RID instead of VID Add default attributes for TAM objects
Original PR: https://github.com/sonic-net/sonic-sairedis/pull/1606